### PR TITLE
Optimize slow init functions (execution time ~25% faster)

### DIFF
--- a/ninjadroid/signatures/shell_command_signature.py
+++ b/ninjadroid/signatures/shell_command_signature.py
@@ -16,8 +16,8 @@ class ShellCommandSignature(Signature):
     def __init__(self):
         super(ShellCommandSignature, self).__init__()
 
-    @classmethod
-    def _compile_regex(cls, signatures: Dict):
+    @staticmethod
+    def _compile_regex(signatures: Dict):
         regex = r'('
 
         # Shell command:
@@ -38,5 +38,7 @@ class ShellCommandSignature(Signature):
 
         regex += r')'
 
-        cls._is_regex = re.compile(regex, re.IGNORECASE)
-        cls._is_contained_regex = re.compile(regex, re.IGNORECASE)
+        _is_regex = re.compile(regex, re.IGNORECASE)
+        _is_contained_regex = re.compile(regex, re.IGNORECASE)
+
+        return (_is_regex, _is_contained_regex)

--- a/ninjadroid/signatures/signature.py
+++ b/ninjadroid/signatures/signature.py
@@ -8,20 +8,25 @@ class Signature:
     """
     Parser for generic signature.
     """
-
     _CONFIG_FILE = os.path.join(os.path.dirname(__file__), "..", "config", "signatures.json")
     _SIGNATURE_KEYS_LIST = ["signatures"]
+    _IS_REGEX = None
+    _IS_CONTAINED_REGEX = None
 
     def __init__(self):
-        signatures_regex = self._get_signature_regex_from_config()
-        self._compile_regex(signatures_regex)
+        # Note: _IS_REGEX and _IS_CONTAINED_REGEX are time-consuming to compile. Since
+        # they don't change at runtime we can do this just once.
+        if self._IS_REGEX is None or self._IS_CONTAINED_REGEX is None:
+            signatures_regex = self._get_signature_regex_from_config()
+            (self._IS_REGEX, self._IS_CONTAINED_REGEX) = self._compile_regex(signatures_regex)
 
-    def _get_signature_regex_from_config(self):
+    @classmethod
+    def _get_signature_regex_from_config(cls):
         signatures_regex = {}
-        with open(self._CONFIG_FILE, "r") as config_file:
+        with open(cls._CONFIG_FILE, "r") as config_file:
             config = json.load(config_file)
 
-            for signature_name in self._SIGNATURE_KEYS_LIST:
+            for signature_name in cls._SIGNATURE_KEYS_LIST:
                 signatures_list = config[signature_name]
                 signatures_list.reverse()
 
@@ -32,12 +37,14 @@ class Signature:
                 signatures_regex[signature_name] = signatures_regex[signature_name][:-1]
         return signatures_regex
 
-    @classmethod
-    def _compile_regex(cls, signatures: Dict):
+    @staticmethod
+    def _compile_regex(signatures: Dict):
         """
-        Compile the Shell commands signature regex.
+        Compile the Shell commands signature regexes.
 
-        :param signatures: Dictionary of the signature regex, whose keys are the ones declared in _SIGNATURE_KEYS_LIST.
+        :param signatures: Dictionary of the signature regex, whose keys are the ones declared in
+          _SIGNATURE_KEYS_LIST.
+        :returns: tuple of compiled regexes
         """
         regex = r'('
 
@@ -51,20 +58,22 @@ class Signature:
 
         regex += r')'
 
-        cls._is_regex = re.compile(r'^' + regex + r'$', re.IGNORECASE)
-        cls._is_contained_regex = re.compile(regex, re.IGNORECASE)
+        _is_regex = re.compile(r'^' + regex + r'$', re.IGNORECASE)
+        _is_contained_regex = re.compile(regex, re.IGNORECASE)
+
+        return (_is_regex, _is_contained_regex)
 
     def is_valid(self, signature: str) -> bool:
         if signature is None or signature == "":
             return False
 
-        return self._is_regex.search(signature)
+        return self._IS_REGEX.search(signature)
 
     def get_matches_in_string(self, string: str) -> str:
         if string is None or string == "":
             return ""
 
-        match = self._is_contained_regex.search(string)
+        match = self._IS_CONTAINED_REGEX.search(string)
 
         if match is not None and match.group(0) is not None:
             return str(match.group(0)).strip()

--- a/ninjadroid/signatures/uri_signature.py
+++ b/ninjadroid/signatures/uri_signature.py
@@ -16,8 +16,8 @@ class URISignature(Signature):
     def __init__(self):
         super(URISignature, self).__init__()
 
-    @classmethod
-    def _compile_regex(cls, signatures: Dict):
+    @staticmethod
+    def _compile_regex(signatures: Dict):
         regex = r'('
 
         # Scheme (HTTP, HTTPS, FTP and SFTP):
@@ -50,5 +50,7 @@ class URISignature(Signature):
 
         regex += r')'
 
-        cls._is_regex = re.compile(r'^' + regex + r'$', re.IGNORECASE)
-        cls._is_contained_regex = re.compile(regex, re.IGNORECASE)
+        _is_regex = re.compile(r'^' + regex + r'$', re.IGNORECASE)
+        _is_contained_regex = re.compile(regex, re.IGNORECASE)
+
+        return (_is_regex, _is_contained_regex)


### PR DESCRIPTION
I finally got back to the memoize optimization, but went about it in a different, more explicit, but I think clearer way.

The expensive regex compilations are only done one time per class.

Tests pass this time :)